### PR TITLE
Fix repeated toast listeners

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix useToast effect dependency to avoid pushing duplicate listeners

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*