### PR TITLE
Center feature carousel icons

### DIFF
--- a/src/components/FeaturesCarousel.tsx
+++ b/src/components/FeaturesCarousel.tsx
@@ -57,7 +57,7 @@ const FeaturesCarousel = () => {
 
               <div className="grid md:grid-cols-3 gap-8 mt-12">
                 <Card variant="default" className="h-full flex flex-col p-6" hover={true}>
-                  <div className="flex items-center mb-6">
+                  <div className="flex items-center justify-center mb-6">
                     <div className="w-16 h-16 rounded-full bg-blue-100 flex items-center justify-center">
                       <span className="text-blue-600 text-2xl font-bold">2500+</span>
                     </div>
@@ -72,7 +72,7 @@ const FeaturesCarousel = () => {
                 </Card>
 
                 <Card variant="default" className="h-full flex flex-col p-6" hover={true}>
-                  <div className="flex items-center mb-6">
+                  <div className="flex items-center justify-center mb-6">
                     <div className="w-16 h-16 rounded-full bg-purple-100 flex items-center justify-center">
                       <span className="text-purple-600 text-2xl font-bold">$540M</span>
                     </div>
@@ -86,7 +86,7 @@ const FeaturesCarousel = () => {
                 </Card>
 
                 <Card variant="default" className="h-full flex flex-col p-6" hover={true}>
-                  <div className="flex items-center mb-6">
+                  <div className="flex items-center justify-center mb-6">
                     <div className="w-16 h-16 rounded-full bg-blue-100 flex items-center justify-center">
                       <span className="text-blue-600 text-2xl font-bold">2000+</span>
                     </div>
@@ -119,7 +119,7 @@ const FeaturesCarousel = () => {
 
               <div className="grid md:grid-cols-3 gap-8 mt-12">
                 <Card variant="feature" className="h-full flex flex-col p-6">
-                  <div className="flex items-center mb-6">
+                  <div className="flex items-center justify-center mb-6">
                     <div className="w-12 h-12 rounded-full bg-blue-500/20 flex items-center justify-center">
                       <svg className="w-6 h-6 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
@@ -136,7 +136,7 @@ const FeaturesCarousel = () => {
                 </Card>
 
                 <Card variant="feature" className="h-full flex flex-col p-6">
-                  <div className="flex items-center mb-6">
+                  <div className="flex items-center justify-center mb-6">
                     <div className="w-12 h-12 rounded-full bg-purple-500/20 flex items-center justify-center">
                       <svg className="w-6 h-6 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
@@ -154,7 +154,7 @@ const FeaturesCarousel = () => {
                 </Card>
 
                 <Card variant="feature" className="h-full flex flex-col p-6">
-                  <div className="flex items-center mb-6">
+                  <div className="flex items-center justify-center mb-6">
                     <div className="w-12 h-12 rounded-full bg-purple-500/20 flex items-center justify-center">
                       <svg className="w-6 h-6 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />


### PR DESCRIPTION
## Summary
- center numeric icons in FeaturesCarousel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*